### PR TITLE
Replace the usage of V2 API by the V3 and add support for reporting

### DIFF
--- a/Tests/Transport/InfobipApiTransportTest.php
+++ b/Tests/Transport/InfobipApiTransportTest.php
@@ -70,7 +70,7 @@ class InfobipApiTransportTest extends TestCase
         $this->transport->send($email);
 
         $this->assertSame('POST', $this->response->getRequestMethod());
-        $this->assertSame('https://99999.api.infobip.com/email/2/send', $this->response->getRequestUrl());
+        $this->assertSame('https://99999.api.infobip.com/email/3/send', $this->response->getRequestUrl());
         $options = $this->response->getRequestOptions();
         $this->arrayHasKey('headers');
         $this->assertCount(4, $options['headers']);

--- a/Transport/InfobipApiTransport.php
+++ b/Transport/InfobipApiTransport.php
@@ -31,7 +31,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InfobipApiTransport extends AbstractApiTransport
 {
-    private const API_VERSION = '2';
+    private const API_VERSION = '3';
 
     private string $key;
 
@@ -122,6 +122,22 @@ final class InfobipApiTransport extends AbstractApiTransport
         }
 
         $this->attachmentsFormData($fields, $email);
+
+        if ($email->getHeaders()->has('intermediateReport')) {
+            $fields['intermediateReport'] = $email->getHeaders()->getHeaderBody('intermediateReport');
+        }
+
+        if ($email->getHeaders()->has('notifyUrl')) {
+            $fields['notifyUrl'] = $email->getHeaders()->getHeaderBody('notifyUrl');
+        }
+
+        if ($email->getHeaders()->has('notifyContentType')) {
+            $fields['notifyContentType'] = $email->getHeaders()->getHeaderBody('notifyContentType');
+        }
+
+        if ($email->getHeaders()->has('messageId')) {
+            $fields['messageId'] = $email->getHeaders()->getHeaderBody('messageId');
+        }
 
         return new FormDataPart($fields);
     }


### PR DESCRIPTION
# 📍 Context

Infobip send an email to their customers that do not use the latest API release: **V3**

They inform that everything is backward compatible and can be easily upgraded without any changes.

As a need in our company and, maybe by some other users, we need the support for reporting.

# 🛠️ Changes

This PR change the version used from the V2 to the V3.

# ➕ New feature

New payload attributes was added allowing end users to use the reporting.

| Attribute | Type | Description |
| --- | --- | --- |
|  intermediateReport | boolean | The real-time Intermediate delivery report that will be sent on your callback server. | 
| notifyUrl | string | The URL on your callback server on which the Delivery report will be sent. | 
| notifyContentType | string | Preferred Delivery report content type. Can be `application/json` or `application/xml`. |
| messageId | string | The ID that uniquely identifies the message sent to a recipient. |

ℹ️ Note that no one of this attributes are required.

